### PR TITLE
[Challenge-14.2] Add support for longer constant indexes

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -20,6 +20,8 @@
         "limits": "c",
         "ratio": "c",
         "variant": "c",
-        "value.h": "c"
+        "value.h": "c",
+        "streambuf": "c",
+        "debug.h": "c"
     }
 }

--- a/src/chunk.c
+++ b/src/chunk.c
@@ -1,5 +1,6 @@
 #include "chunk.h"
 
+#include <limits.h>
 #include <stdlib.h>
 
 #include "memory.h"
@@ -26,6 +27,51 @@ void writeChunk(Chunk* chunk, uint8_t byte, int line) {
     // Keep line info in array parallel with code
     chunk->lines[chunk->count] = line;
     chunk->count++;
+}
+
+/* Add value to chunks constant arary and write an appropriate instruction to load the constant.*/
+void writeConstant(Chunk* chunk, Value value, int line) {
+    OpCode instruction;
+    int constant_index_size;
+
+    if (chunk->constants.count < UCHAR_MAX) {
+        instruction = OP_CONSTANT;
+        constant_index_size = 1;
+    } else {
+        instruction = OP_CONSTANT_LONG;
+        constant_index_size = 3;
+    }
+
+    // If needed, grow array by (instruction byte + constant index)
+    if (chunk->capacity < chunk->count + (1 + constant_index_size)) {
+        int oldCapacity = chunk->capacity;
+        chunk->capacity = GROW_CAPACITY(oldCapacity);
+        chunk->code = GROW_ARRAY(uint8_t, chunk->code, oldCapacity, chunk->capacity);
+        chunk->lines = GROW_ARRAY(int, chunk->lines, oldCapacity, chunk->capacity);
+    }
+
+    // Write value to array
+    int constant_index = addConstant(chunk, value);
+
+    // Write instruction
+    chunk->code[chunk->count] = instruction;
+    // Keep line info in array parallel with code
+    chunk->lines[chunk->count] = line;
+
+    // Then write constant index in the next 1 or 3 blocks
+    if (constant_index < UCHAR_MAX) {
+        chunk->code[chunk->count + 1] = constant_index;
+        chunk->lines[chunk->count + 1] = line;
+    } else {
+        chunk->code[chunk->count + 1] = (uint8_t)((constant_index & 0x00FF0000) >> 16);
+        chunk->code[chunk->count + 2] = (uint8_t)((constant_index & 0x0000FF00) >> 8);
+        chunk->code[chunk->count + 3] = (uint8_t)(constant_index & 0x000000FF);
+        chunk->lines[chunk->count + 1] = line;
+        chunk->lines[chunk->count + 2] = line;
+        chunk->lines[chunk->count + 3] = line;
+    }
+
+    chunk->count = chunk->count + constant_index_size + 1;
 }
 
 /*  Add a constant to the chunk, return its index */

--- a/src/chunk.h
+++ b/src/chunk.h
@@ -8,6 +8,7 @@
 typedef enum {
     OP_RETURN, // One-byte opcode
     OP_CONSTANT, // Two bytes: opcode, constant index (operand)
+    OP_CONSTANT_LONG, // Four bytes: opcode, 24-bit constant index (operand)
 } OpCode;
 
 // Chunk is a dynamic array used to store other data along with instruction
@@ -22,6 +23,7 @@ typedef struct {
 void initChunk(Chunk* chunk);
 void freeChunk(Chunk* chunk);
 void writeChunk(Chunk* chunk, uint8_t byte, int line);
+void writeConstant(Chunk* chunk, Value value, int line);
 int addConstant(Chunk* chunk, Value value);
 
 #endif

--- a/src/debug.c
+++ b/src/debug.c
@@ -29,6 +29,18 @@ static int constantInstruction(const char* name, Chunk* chunk, int offset) {
     return offset + 2;
 }
 
+static int constantLongInstruction(const char* name, Chunk* chunk, int offset) {
+    int constant_index = chunk->code[offset + 1] << 16 | chunk->code[offset + 2] << 8 | chunk->code[offset + 3];
+
+    // Print opcode name and constant index from subsequent 3 bytes in chunk.
+    printf("%-16s %8d '", name, constant_index);
+    // Print actual value of the constant (which is know at compile time)
+    printValue(chunk->constants.values[constant_index]);
+    printf("'\n");
+
+    return offset + 4;
+}
+
 /* Print instruction; Return the number of the offset of the next instruction. */
 int disassembleInstruction(Chunk* chunk, int offset) {
     printf("%04d ", offset);
@@ -46,6 +58,8 @@ int disassembleInstruction(Chunk* chunk, int offset) {
             return simpleInstruction("OP_RETURN", offset);
         case OP_CONSTANT:
             return constantInstruction("OP_CONSTANT", chunk, offset);
+        case OP_CONSTANT_LONG:
+            return constantLongInstruction("OP_CONSTANT_LONG", chunk, offset);
         default:
             printf("Unknown opcode %d\n", instruction);
             return offset + 1;

--- a/src/main.c
+++ b/src/main.c
@@ -6,9 +6,9 @@ int main(int arc, const char *argv[]) {
     Chunk chunk;
     initChunk(&chunk);
 
-    int constant = addConstant(&chunk, 1.2);
-    writeChunk(&chunk, OP_CONSTANT, 42);
-    writeChunk(&chunk, constant, 42);
+    for (int i = 0; i < 300; i++) {
+        writeConstant(&chunk, 1000 + i, 10);
+    }
 
     writeChunk(&chunk, OP_RETURN, 42);
 


### PR DESCRIPTION
This PR adds support for longer (24-bit) constant references in `Chunk`. Before, the user's only option was `OP_CONSTANT`, while can only refer to 255 constants. (`OP_CONSTANT` uses one byte to refer to the index position of the constant in `ValueArray`.) This PR adds `OP_CONSTANT_LONG`, which uses 3 bytes and allows the user to refer to 2^24 - 1 constants.
- Add `OP_CONSTANT_LONG`.
- Add `writeConstant` to add a `Value` to a `Chunk`'s constant array and write an appropriate instruction to load the constant.
- Add support for disassembling/debugging `OP_CONSTANT_LONG`.