### PR TITLE
[Challenge 20.1] Allow all Value types to be used as table keys

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -26,7 +26,10 @@
         "common.h": "c",
         "string.h": "c",
         "scanner.h": "c",
-        "debug.h": "c"
+        "debug.h": "c",
+        "__locale": "c",
+        "__threading_support": "c",
+        "cmath": "c"
     },
     "editor.formatOnSave": true
 }

--- a/src/object.c
+++ b/src/object.c
@@ -34,7 +34,7 @@ static ObjString* allocateString(char* chars, int length,
     string->chars = chars;
     string->hash = hash;
     // Intern every string we create
-    tableSet(&vm.strings, string, NIL_VAL);
+    tableSet(&vm.strings, OBJ_VAL(string), NIL_VAL);
     return string;
 }
 

--- a/src/table.h
+++ b/src/table.h
@@ -5,7 +5,7 @@
 #include "value.h"
 
 typedef struct {
-    ObjString* key;  // Lox keys are always strings
+    Value key;  // Lox keys are always strings
     Value value;
 } Entry;
 
@@ -17,9 +17,9 @@ typedef struct {
 
 void initTable(Table* table);
 void freeTable(Table* table);
-bool tableGet(Table* table, ObjString* key, Value* value);
-bool tableSet(Table* table, ObjString* key, Value value);
-bool tableDelete(Table* table, ObjString* key);
+bool tableGet(Table* table, Value key, Value* value);
+bool tableSet(Table* table, Value key, Value value);
+bool tableDelete(Table* table, Value key);
 void tableAddAll(Table* from, Table* to);
 ObjString* tableFindString(Table* table, const char* chars, int length, uint32_t hash);
 

--- a/src/value.c
+++ b/src/value.c
@@ -43,6 +43,8 @@ void printValue(Value value) {
         case VAL_OBJ:
             printObject(value);
             break;
+        case VAL_EMPTY:
+            printf("empty");
     }
 }
 
@@ -59,5 +61,45 @@ bool valuesEqual(Value a, Value b) {
             return AS_OBJ(a) == AS_OBJ(b);
         default:
             return false;  // Unreachable.
+    }
+}
+
+/* Generate hash for a Double.
+Uses the same algorithm as Lua, which maps the mantissa to the integer range and combines it with the exponent.
+Reference: https://readafterwrite.wordpress.com/2017/03/23/floating-point-keys-in-lua/
+https://github.com/lua/lua/blob/e15f1f2bb7a38a3c94519294d031e48508d65006/ltable.c#L131
+*/
+static uint32_t hashDouble(double n) {
+    if (isinf(n) || isnan(n))
+        return 0;
+
+    // Signed mantissa
+    // n = m·2^exp. mantissa is normalized so |m| in [0.5,1)
+    int32_t exp;
+    double m = frexp(n, &exp);
+
+    // Map mantissa to integer range
+    // There's a bit of magic here, but essentially it extracts (only) the most significant bits
+    int32_t mi = (int32_t)(m * -(double)INT_MIN);
+
+    // Add mantissa and exponent
+    uint32_t u = (uint32_t)exp + (uint32_t)mi;
+    return u >= (uint32_t)INT_MAX ? u : ~u;
+}
+
+u_int32_t hashValue(Value value) {
+    switch (value.type) {
+        case VAL_BOOL:
+            return AS_BOOL(value) ? 2 : 1;
+        case VAL_NIL:
+            return 3;
+        case VAL_NUMBER:
+            return hashDouble(AS_NUMBER(value));
+        case VAL_OBJ:
+            return AS_STRING(value)->hash;
+        case VAL_EMPTY:
+            return 0;
+        default:
+            break;
     }
 }

--- a/src/value.h
+++ b/src/value.h
@@ -1,6 +1,9 @@
 #ifndef clox_value_h
 #define clox_value_h
 
+#include <limits.h>
+#include <math.h>
+
 #include "common.h"
 
 typedef struct Obj Obj;
@@ -12,6 +15,7 @@ typedef enum {
     VAL_NIL,
     VAL_NUMBER,
     VAL_OBJ,  // any value whose state lives on the heap
+    VAL_EMPTY
 } ValueType;
 
 // Values are doubles that OP_CONSTANTS refer to (via an index).
@@ -29,6 +33,7 @@ typedef struct {
 #define IS_NIL(value) ((value).type == VAL_NIL)
 #define IS_NUMBER(value) ((value).type == VAL_NUMBER)
 #define IS_OBJ(value) ((value).type == VAL_OBJ)
+#define IS_EMPTY(value) ((value).type == VAL_EMPTY)
 
 // Unpack a value and get the C value back out.
 // 'value' needs to be of the correct type! Use the IS_ macros to check.
@@ -42,6 +47,7 @@ typedef struct {
 #define NIL_VAL ((Value){VAL_NIL, {.number = 0}})
 #define NUMBER_VAL(value) ((Value){VAL_NUMBER, {.number = value}})
 #define OBJ_VAL(object) ((Value){VAL_OBJ, {.obj = (Obj*)object}})
+#define EMPTY_VAL ((Value){VAL_EMPTY, {.number = 0}})
 
 // Value array is similar to the JVM's constant pool
 typedef struct {
@@ -55,5 +61,6 @@ void initValueArray(ValueArray* array);
 void writeValueArray(ValueArray* array, Value value);
 void freeValueArray(ValueArray* array);
 void printValue(Value value);
+uint32_t hashValue(Value value);
 
 #endif


### PR DESCRIPTION
I took the float hashing function, `hashDouble`, from Lua:
- https://readafterwrite.wordpress.com/2017/03/23/floating-point-keys-in-lua/
- https://github.com/lua/lua/blob/e15f1f2bb7a38a3c94519294d031e48508d65006/ltable.c#L131