### PR TITLE
Chapter 22 - Local Variables

### DIFF
--- a/src/chunk.h
+++ b/src/chunk.h
@@ -11,6 +11,8 @@ typedef enum {
     OP_TRUE,
     OP_FALSE,
     OP_POP,
+    OP_GET_LOCAL,
+    OP_SET_LOCAL,
     OP_GET_GLOBAL,
     OP_DEFINE_GLOBAL,
     OP_SET_GLOBAL,

--- a/src/common.h
+++ b/src/common.h
@@ -8,4 +8,6 @@
 #define DEBUG_PRINT_CODE
 #define DEBUG_TRACE_EXECUTION
 
+#define UINT8_COUNT (UINT8_MAX + 1)
+
 #endif

--- a/src/compiler.c
+++ b/src/compiler.c
@@ -378,7 +378,7 @@ static void namedVariable(Token name, bool canAssign) {
     } else {
         // Take the given identifier token, add lexeme to chunk's constant table as a string.
         // We need to do this because global vars are referenced by name, and we don't want to put a whole string in the bytecode
-        uint8_t arg = identifierConstant(&name);
+        arg = identifierConstant(&name);
         getOp = OP_GET_GLOBAL;
         setOp = OP_SET_GLOBAL;
     }

--- a/src/compiler.c
+++ b/src/compiler.c
@@ -2,6 +2,7 @@
 
 #include <stdio.h>
 #include <stdlib.h>
+#include <string.h>
 
 #include "common.h"
 #include "scanner.h"
@@ -170,6 +171,21 @@ static void endCompiler() {
 #endif
 }
 
+static void beginScope() {
+    current->scopeDepth++;
+}
+
+static void endScope() {
+    current->scopeDepth--;
+
+    // Delete locals
+    while (current->localCount > 0 && current->locals[current->localCount - 1].depth > current->scopeDepth) {
+        // TODO(optimization): Add OP_POPN and use it here
+        emitByte(OP_POP);
+        current->localCount--;
+    }
+}
+
 static void expression();
 static void statement();
 static void declaration();
@@ -182,15 +198,89 @@ static uint8_t identifierConstant(Token* name) {
                                            name->length)));
 }
 
+/* Check if two identifiers are the same */
+static bool identifiersEqual(Token* a, Token* b) {
+    if (a->length != b->length) return false;
+    return memcmp(a->start, b->start, a->length) == 0;
+}
+
+/* Resolve local variable. Returns the variable's index in the Compiler's array of locals or -1 if not found.
+
+The indices int the Compiler's locals array matches the VM's stack at runtime.  */
+static int resolveLocal(Compiler* compiler, Token* name) {
+    // Walk list of locals currently in scope
+    // Walk back so inner locals shadow outer ones
+    for (int i = compiler->localCount - 1; i >= 0; i--) {
+        Local* local = &compiler->locals[i];
+        if (identifiersEqual(name, &local->name)) {
+            if (local->depth == -1) {
+                error("Can't read local variable in its own initializer.");
+            }
+            return i;
+        }
+    }
+    return -1;  // Assume to be a local
+}
+
+/* Initialize next available Local in the compiler's array of local variables. */
+static void addLocal(Token name) {
+    if (current->localCount == UINT8_COUNT) {
+        error("Too many local variables in function.");
+        return;
+    }
+
+    Local* local = &current->locals[current->localCount++];
+    local->name = name;
+    local->depth = -1;  // Sentinel value
+}
+
+/* Record the existence of a variable, i.e. add it to the scope */
+static void declareVariable() {
+    // Not applicable to globals
+    if (current->scopeDepth == 0) return;
+
+    Token* name = &parser.previous;
+
+    for (int i = current->localCount - 1; i >= 0; i--) {
+        Local* local = &current->locals[i];
+        if (local->depth != -1 && local->depth < current->scopeDepth) {
+            break;
+        }
+
+        if (identifiersEqual(name, &local->name)) {
+            error("Already a variable with this name in this scope.");
+        }
+    }
+
+    addLocal(*name);
+}
+
 /* Consume identifier, put it in constant table, return constant index. */
 static uint8_t parseVariable(const char* errorMessage) {
     consume(TOKEN_IDENTIFIER, errorMessage);
+
+    declareVariable();
+    // At runtime, locals aren't looked up by name
+    if (current->scopeDepth > 0) return 0;
+
     return identifierConstant(&parser.previous);
 }
 
-/* Output bytecode instruction that defines the new variable and stores its initial value.
-the instruction’s operand is the index of the variable’s name in the Chunk's constant table. */
+/* Assign scope depth to variable. */
+static void markInitialized() {
+    current->locals[current->localCount - 1].depth = current->scopeDepth;
+};
+
+/* Output bytecode instruction that defines the new variable and stores its initial value. Make variable available for use.
+
+The instruction’s operand is the index of the variable’s name in the Chunk's constant table. */
 static void defineVariable(uint8_t global) {
+    // Locals aren'tstored in the constants table
+    if (current->scopeDepth > 0) {
+        markInitialized();
+        return;
+    }
+
     emitBytes(OP_DEFINE_GLOBAL, global);
 }
 
@@ -280,17 +370,25 @@ static void string(bool canAssign) {
 
 /* Emit instruciton to load global variable. */
 static void namedVariable(Token name, bool canAssign) {
-    // Take the given identifier token, add lexeme to chunk's constant table as a string.
-    // We need to do this because global vars are referenced by name, and we don't want to put a whole string in the bytecode
-    uint8_t arg = identifierConstant(&name);
+    uint8_t getOp, setOp;
+    int arg = resolveLocal(current, &name);
+    if (arg != -1) {
+        getOp = OP_GET_LOCAL;
+        setOp = OP_SET_LOCAL;
+    } else {
+        // Take the given identifier token, add lexeme to chunk's constant table as a string.
+        // We need to do this because global vars are referenced by name, and we don't want to put a whole string in the bytecode
+        uint8_t arg = identifierConstant(&name);
+        getOp = OP_GET_GLOBAL;
+        setOp = OP_SET_GLOBAL;
+    }
 
     // if there's an '=' after the identifier, compile the assigned value
     if (canAssign && match(TOKEN_EQUAL)) {
         expression();
-        emitBytes(OP_SET_GLOBAL, arg);
+        emitBytes(setOp, (uint8_t)arg);
     } else {
-        // Instruction to load the global variale with that name
-        emitBytes(OP_GET_GLOBAL, arg);
+        emitBytes(getOp, (uint8_t)arg);
     }
 }
 
@@ -411,6 +509,14 @@ static void expression() {
     parsePrecedence(PREC_ASSIGNMENT);
 }
 
+static void block() {
+    while (!check(TOKEN_RIGHT_BRACE) && !check(TOKEN_EOF)) {
+        declaration();
+    }
+
+    consume(TOKEN_RIGHT_BRACE, "Expect '}' after block.");
+}
+
 static void varDeclaration() {
     uint8_t global = parseVariable("Expect variable name.");
 
@@ -480,6 +586,10 @@ static void declaration() {
 static void statement() {
     if (match(TOKEN_PRINT)) {
         printStatement();
+    } else if (match(TOKEN_LEFT_BRACE)) {
+        beginScope();
+        block();
+        endScope();
     } else {
         expressionStatement();
     }

--- a/src/debug.c
+++ b/src/debug.c
@@ -17,6 +17,13 @@ static int simpleInstruction(const char* name, int offset) {
     return offset + 1;
 }
 
+static int byteInstruction(const char* name, Chunk* chunk,
+                           int offset) {
+    uint8_t slot = chunk->code[offset + 1];
+    printf("%-16s %4d\n", name, slot);
+    return offset + 2;
+}
+
 static int constantInstruction(const char* name, Chunk* chunk, int offset) {
     uint8_t constant = chunk->code[offset + 1];
 
@@ -52,6 +59,10 @@ int disassembleInstruction(Chunk* chunk, int offset) {
             return simpleInstruction("OP_FALSE", offset);
         case OP_POP:
             return simpleInstruction("OP_POP", offset);
+        case OP_GET_LOCAL:
+            return byteInstruction("OP_GET_LOCAL", chunk, offset);
+        case OP_SET_LOCAL:
+            return byteInstruction("OP_SET_LOCAL", chunk, offset);
         case OP_GET_GLOBAL:
             return constantInstruction("OP_GET_GLOBAL", chunk, offset);
         case OP_DEFINE_GLOBAL:

--- a/src/vm.c
+++ b/src/vm.c
@@ -140,6 +140,17 @@ static InterpretResult run() {
                 // Pop top of the stack and forget it.
                 pop();
                 break;
+            case OP_GET_LOCAL: {
+                uint8_t slot = READ_BYTE();
+                push(vm.stack[slot]);
+                break;
+            }
+            case OP_SET_LOCAL: {
+                // Take the assigned value from top of stack and store it in the stack slot corresponding to the local variable
+                uint8_t slot = READ_BYTE();
+                vm.stack[slot] = peek(0);
+                break;
+            }
             case OP_GET_GLOBAL: {
                 // Pull the constant table index from the instructions operand and read the string
                 ObjString* name = READ_STRING();

--- a/test/chap22_locals.clox
+++ b/test/chap22_locals.clox
@@ -1,0 +1,1 @@
+{ var a = 1; { var a = 2; var b = a + 2; } }


### PR DESCRIPTION
Add local variables. 

Details:
- Locals are lexically-scoped, i.e. not late bound like globals.
- Two variables in the same scope depth cannot have the same name.
- Locals live in the VM's stack for fast access.
- Locals have the same index in the Compiler's array of locals and the VM's stack array.
- Variable declaration (adding to scope) and definition (making it ready to use) are separate stages.