### PR TITLE
Chapter 24 - Functions

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -32,7 +32,9 @@
         "cmath": "c",
         "complex": "c",
         "functional": "c",
-        "locale": "c"
+        "locale": "c",
+        "unordered_map": "c",
+        "ios": "c"
     },
     "editor.formatOnSave": true
 }

--- a/src/chunk.h
+++ b/src/chunk.h
@@ -29,6 +29,7 @@ typedef enum {
     OP_JUMP,
     OP_JUMP_IF_FALSE,
     OP_LOOP,
+    OP_CALL,
     OP_RETURN,  // One-byte opcode
 } OpCode;
 

--- a/src/common.h
+++ b/src/common.h
@@ -5,8 +5,8 @@
 #include <stddef.h>
 #include <stdint.h>
 
-#define DEBUG_PRINT_CODE
-#define DEBUG_TRACE_EXECUTION
+// #define DEBUG_PRINT_CODE
+// #define DEBUG_TRACE_EXECUTION
 
 #define UINT8_COUNT (UINT8_MAX + 1)
 

--- a/src/compiler.c
+++ b/src/compiler.c
@@ -47,7 +47,17 @@ typedef struct {
     int depth;  // the scope depth of the block where the local var was declared.
 } Local;
 
-typedef struct {
+// Differentiates between top-level code and function body
+typedef enum {
+    TYPE_FUNCTION,
+    TYPE_SCRIPT
+} FunctionType;
+
+typedef struct Compiler {
+    struct Compiler* enclosing;
+    ObjFunction* function;
+    FunctionType type;
+
     Local locals[UINT8_COUNT];  // locals in scope during compilation. Max 256 in scope at once.
     int localCount;             // number of locals in scope
     int scopeDepth;             // number of blocks surrounding current bit of code being compiled
@@ -58,7 +68,7 @@ Compiler* current = NULL;
 Chunk* compilingChunk;
 
 static Chunk* currentChunk() {
-    return compilingChunk;
+    return &current->function->chunk;
 }
 
 static void errorAt(Token* token, const char* message) {
@@ -156,7 +166,9 @@ static int emitJump(uint8_t instruction) {
     return currentChunk()->count - 2;
 }
 
-static void emitReturn() {
+/* Emit an OP_RETURN and implicitly return nil. Meant to be called at the end of functions. */
+static void emitNilReturn() {
+    emitByte(OP_NIL);  // Implicitly return nil for functions that don't return anything.
     emitByte(OP_RETURN);
 }
 
@@ -188,19 +200,37 @@ static void patchJump(int offset) {
     currentChunk()->code[offset + 1] = jump & 0xff;
 }
 
-static void initCompiler(Compiler* compiler) {
+static void initCompiler(Compiler* compiler, FunctionType type) {
+    compiler->enclosing = current;
+    compiler->function = NULL;
+    compiler->type = type;
     compiler->localCount = 0;
     compiler->scopeDepth = 0;
+    compiler->function = newFunction();
     current = compiler;
+    if (type != TYPE_SCRIPT) {
+        current->function->name = copyString(parser.previous.start,
+                                             parser.previous.length);
+    }
+
+    // Claim the first `locals` slot for the VM's internal use
+    Local* local = &current->locals[current->localCount++];
+    local->depth = 0;
+    local->name.start = "";  // Can't be referred to by the user
+    local->name.length = 0;
 }
 
-static void endCompiler() {
-    emitReturn();
+static ObjFunction* endCompiler() {
+    emitNilReturn();
+    ObjFunction* function = current->function;
+
 #ifdef DEBUG_PRINT_CODE
     if (!parser.hadError) {
-        disassembleChunk(currentChunk(), "code");
+        disassembleChunk(currentChunk(), function->name != NULL ? function->name->chars : "<script>");
     }
 #endif
+    current = current->enclosing;
+    return function;
 }
 
 static void beginScope() {
@@ -300,6 +330,7 @@ static uint8_t parseVariable(const char* errorMessage) {
 
 /* Assign scope depth to variable. */
 static void markInitialized() {
+    if (current->scopeDepth == 0) return;  // If markInitialized is called by a global...
     current->locals[current->localCount - 1].depth = current->scopeDepth;
 };
 
@@ -314,6 +345,22 @@ static void defineVariable(uint8_t global) {
     }
 
     emitBytes(OP_DEFINE_GLOBAL, global);
+}
+
+/* Consume arguments and put them on the stack */
+static uint8_t argumentList() {
+    uint8_t argCount = 0;
+    if (!check(TOKEN_RIGHT_PAREN)) {
+        do {
+            expression();
+            if (argCount == 255) {
+                error("Can't have more than 255 arguments.");
+            }
+            argCount++;
+        } while (match(TOKEN_COMMA));
+    }
+    consume(TOKEN_RIGHT_PAREN, "Expect ')' after arguments.");
+    return argCount;
 }
 
 /* Compile AND expression. Short-circuit if appropriate. */
@@ -373,6 +420,12 @@ static void binary(bool canAssign) {
         default:
             return;  // Unreachable.
     }
+}
+
+/* Function call */
+static void call(bool canAssign) {
+    uint8_t argCount = argumentList();  // Put N arguments on the stack
+    emitBytes(OP_CALL, argCount);
 }
 
 /* Push literals onto the stack */
@@ -481,7 +534,7 @@ static void unary(bool canAssign) {
  *
  * TODO(optimization): add more specific instrucitons and benchmark (e.g. small int constants, adding and subtracting 1, etc*/
 ParseRule rules[] = {
-    [TOKEN_LEFT_PAREN] = {grouping, NULL, PREC_NONE},
+    [TOKEN_LEFT_PAREN] = {grouping, call, PREC_CALL},
     [TOKEN_RIGHT_PAREN] = {NULL, NULL, PREC_NONE},
     [TOKEN_LEFT_BRACE] = {NULL, NULL, PREC_NONE},
     [TOKEN_RIGHT_BRACE] = {NULL, NULL, PREC_NONE},
@@ -569,6 +622,38 @@ static void block() {
     }
 
     consume(TOKEN_RIGHT_BRACE, "Expect '}' after block.");
+}
+
+static void function(FunctionType type) {
+    Compiler compiler;
+    initCompiler(&compiler, type);
+    beginScope();
+
+    consume(TOKEN_LEFT_PAREN, "Expect '(' after function name.");
+    if (!check(TOKEN_RIGHT_PAREN)) {
+        do {
+            current->function->arity++;
+            if (current->function->arity > 255) {
+                errorAtCurrent("Can't have more than 255 parameters.");
+            }
+            uint8_t constant = parseVariable("Expect parameter name.");
+            defineVariable(constant);
+        } while (match(TOKEN_COMMA));
+    }
+
+    consume(TOKEN_RIGHT_PAREN, "Expect ')' after parameters.");
+    consume(TOKEN_LEFT_BRACE, "Expect '{' before function body.");
+    block();
+
+    ObjFunction* function = endCompiler();
+    emitBytes(OP_CONSTANT, makeConstant(OBJ_VAL(function)));
+}
+
+static void funDeclaration() {
+    uint8_t global = parseVariable("Expect function name.");
+    markInitialized();  // mark function as initialized so we can reference it inside the body as we compile it. This enables recursion.
+    function(TYPE_FUNCTION);
+    defineVariable(global);
 }
 
 static void varDeclaration() {
@@ -670,6 +755,20 @@ static void printStatement() {
     emitByte(OP_PRINT);
 }
 
+static void returnStatement() {
+    if (current->type == TYPE_SCRIPT) {
+        error("Can't return from top-level code.");
+    }
+
+    if (match(TOKEN_SEMICOLON)) {
+        emitNilReturn();
+    } else {
+        expression();
+        consume(TOKEN_SEMICOLON, "Expect ';' after return value.");
+        emitByte(OP_RETURN);
+    }
+}
+
 static void whileStatement() {
     int loopStart = currentChunk()->count;  // At this point we already know where to jump back to.
     consume(TOKEN_LEFT_PAREN, "Expect '(' after 'while'.");
@@ -710,7 +809,9 @@ static void synchronize() {
 
 /* Declarations is one of the two types of statements supported by Lox. They bind a new name to a value. */
 static void declaration() {
-    if (match(TOKEN_VAR)) {
+    if (match(TOKEN_FUN)) {
+        funDeclaration();
+    } else if (match(TOKEN_VAR)) {
         varDeclaration();
     } else {
         statement();
@@ -727,6 +828,8 @@ static void statement() {
         forStatement();
     } else if (match(TOKEN_IF)) {
         ifStatement();
+    } else if (match(TOKEN_RETURN)) {
+        returnStatement();
     } else if (match(TOKEN_WHILE)) {
         whileStatement();
     } else if (match(TOKEN_LEFT_BRACE)) {
@@ -739,11 +842,10 @@ static void statement() {
 }
 
 /* Read char* source and write the code to chunk. */
-bool compile(const char* source, Chunk* chunk) {
+ObjFunction* compile(const char* source) {
     initScanner(source);
     Compiler compiler;
-    initCompiler(&compiler);
-    compilingChunk = chunk;
+    initCompiler(&compiler, TYPE_SCRIPT);
 
     parser.hadError = false;
     parser.panicMode = false;
@@ -754,6 +856,6 @@ bool compile(const char* source, Chunk* chunk) {
         declaration();
     }
 
-    endCompiler();
-    return !parser.hadError;
+    ObjFunction* function = endCompiler();
+    return parser.hadError ? NULL : function;
 }

--- a/src/compiler.h
+++ b/src/compiler.h
@@ -4,6 +4,6 @@
 #include "object.h"
 #include "vm.h"
 
-bool compile(const char* source, Chunk* chunk);
+ObjFunction* compile(const char* source);
 
 #endif

--- a/src/debug.c
+++ b/src/debug.c
@@ -104,6 +104,8 @@ int disassembleInstruction(Chunk* chunk, int offset) {
             return jumpInstruction("OP_JUMP_IF_FALSE", 1, chunk, offset);
         case OP_LOOP:
             return jumpInstruction("OP_LOOP", -1, chunk, offset);
+        case OP_CALL:
+            return byteInstruction("OP_CALL", chunk, offset);
         case OP_RETURN:
             return simpleInstruction("OP_RETURN", offset);
         default:

--- a/src/memory.c
+++ b/src/memory.c
@@ -26,6 +26,15 @@ void* reallocate(void* pointer, size_t oldSize, size_t newSize) {
 // Free an object
 static void freeObject(Obj* object) {
     switch (object->type) {
+        case OBJ_FUNCTION: {
+            ObjFunction* function = (ObjFunction*)object;
+            freeChunk(&function->chunk);
+            FREE(ObjFunction, object);
+            break;
+        }
+        case OBJ_NATIVE:
+            FREE(ObjNative, object);
+            break;
         case OBJ_STRING: {
             ObjString* string = (ObjString*)object;
             FREE_ARRAY(char, string->chars, string->length + 1);

--- a/src/object.c
+++ b/src/object.c
@@ -24,6 +24,22 @@ static Obj* allocateObject(size_t size, ObjType type) {
     return object;
 }
 
+/* Create new Lox function */
+ObjFunction* newFunction() {
+    ObjFunction* function = ALLOCATE_OBJ(ObjFunction, OBJ_FUNCTION);
+    function->arity = 0;
+    initChunk(&function->chunk);
+    function->name = NULL;
+    return function;
+}
+
+/* Create new native function. Take a C function pointer and wrap it in an ObjNative. */
+ObjNative* newNative(NativeFn function) {
+    ObjNative* native = ALLOCATE_OBJ(ObjNative, OBJ_NATIVE);
+    native->function = function;
+    return native;
+}
+
 /* Create new ObjString on the heap and initialize its fields.
 Similar to a constructor in OOP.*/
 static ObjString* allocateString(char* chars, int length,
@@ -79,8 +95,23 @@ ObjString* copyString(const char* chars, int length) {
     return allocateString(heapChars, length, hash);
 }
 
+/* Print the name of a function */
+static void printFunction(ObjFunction* function) {
+    if (function->name == NULL) {
+        printf("<script>");
+        return;
+    }
+    printf("<fn %s>", function->name->chars);
+}
+
 void printObject(Value value) {
     switch (OBJ_TYPE(value)) {
+        case OBJ_FUNCTION:
+            printFunction(AS_FUNCTION(value));
+            break;
+        case OBJ_NATIVE:
+            printf("<native fn>");
+            break;
         case OBJ_STRING:
             printf("%s", AS_CSTRING(value));
             break;

--- a/src/object.h
+++ b/src/object.h
@@ -1,18 +1,25 @@
 #ifndef clox_object_h
 #define clox_object_h
 
+#include "chunk.h"
 #include "common.h"
 #include "value.h"
 
 #define OBJ_TYPE(value) (AS_OBJ(value)->type)
 
+#define IS_FUNCTION(value) isObjType(value, OBJ_FUNCTION)
+#define IS_NATIVE(value) isObjType(value, OBJ_NATIVE)
 #define IS_STRING(value) isObjType(value, OBJ_STRING)
 
+#define AS_FUNCTION(value) ((ObjFunction*)AS_OBJ(value))
+#define AS_NATIVE(value) (((ObjNative*)AS_OBJ(value))->function)
 // These macros take a Value that is expected to have a pointer to a valid ObjString
 #define AS_STRING(value) ((ObjString*)AS_OBJ(value))
 #define AS_CSTRING(value) (((ObjString*)AS_OBJ(value))->chars)
 
 typedef enum {
+    OBJ_FUNCTION,
+    OBJ_NATIVE,
     OBJ_STRING,
 } ObjType;
 
@@ -20,6 +27,21 @@ struct Obj {
     ObjType type;
     struct Obj* next;  // Intrusive pointer to next object for GC
 };
+
+// Functions are first class.
+typedef struct {
+    Obj obj;
+    int arity;
+    Chunk chunk;
+    ObjString* name;
+} ObjFunction;
+
+// Native functions need to be "their own thing" because they don't push a CallFrame when called.
+typedef Value (*NativeFn)(int argCount, Value* args);
+typedef struct {
+    Obj obj;
+    NativeFn function;
+} ObjNative;
 
 // ObjString can be cast to Obj, which allows for a form of OOP.
 // This is because C struct fields are arranged in memory in the order that they are declared
@@ -30,6 +52,8 @@ struct ObjString {
     uint32_t hash;
 };
 
+ObjFunction* newFunction();
+ObjNative* newNative(NativeFn function);
 ObjString* takeString(char* chars, int length);
 ObjString* copyString(const char* chars, int length);
 void printObject(Value value);

--- a/src/vm.h
+++ b/src/vm.h
@@ -2,10 +2,18 @@
 #define clox_vm_h
 
 #include "chunk.h"
+#include "object.h"
 #include "table.h"
 #include "value.h"
 
-#define STACK_MAX 256
+#define FRAMES_MAX 64
+#define STACK_MAX (FRAMES_MAX * UINT8_COUNT)
+
+typedef struct {
+    ObjFunction* function;
+    uint8_t* ip;   // Instruction pointer (aka program counter) that pointer to next instruction to be executed
+    Value* slots;  // where the function's locals begin
+} CallFrame;
 
 typedef enum {
     INTERPRET_OK,
@@ -14,8 +22,9 @@ typedef enum {
 } InterpretResult;
 
 typedef struct {
-    Chunk* chunk;
-    uint8_t* ip;             // Instruction pointer (aka program counter) that pointer to next instruction to be executed
+    CallFrame frames[FRAMES_MAX];
+    int frameCount;  // height of the CallFrame stack == number of ongoing function calls
+
     Value stack[STACK_MAX];  // Array is declared directly inline
     Value* stackTop;         // Use actual pointer instead of int index (faster dereferencing)
     Table globals;           // Global vars

--- a/test/chap24_functions.clox
+++ b/test/chap24_functions.clox
@@ -1,0 +1,8 @@
+fun fib(n) {
+  if (n < 2) return n;
+  return fib(n - 2) + fib(n - 1);
+}
+
+var start = clock();
+print fib(35);
+print clock() - start;


### PR DESCRIPTION
Adds call frames, function calls, and native functions.
- The VM stack is shared amongst call frames.
- Arguments to functions live on the stack. Function read parameters from the stack.
- The stack can hold 64 call frames with 255 variables in each
- Functions that don't return anything return NIL by default
- Native functions don't push a call frame. They use whatever C uses. 
- The `clock()` function is the only native function so far

![image](https://github.com/CaioCamatta/clox/assets/17074399/0a80d6c0-7fbf-4a77-b443-f1785d7b1b2e)
Source: https://craftinginterpreters.com/calls-and-functions.html