### PR TITLE
[wip][Challenge 24.2-4] New and robust native functions

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -41,7 +41,8 @@
         "bitset": "c",
         "__memory": "c",
         "optional": "c",
-        "system_error": "c"
+        "system_error": "c",
+        "memory.h": "c"
     },
     "editor.formatOnSave": true
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -34,7 +34,14 @@
         "functional": "c",
         "locale": "c",
         "unordered_map": "c",
-        "ios": "c"
+        "ios": "c",
+        "__bit_reference": "c",
+        "__node_handle": "c",
+        "atomic": "c",
+        "bitset": "c",
+        "__memory": "c",
+        "optional": "c",
+        "system_error": "c"
     },
     "editor.formatOnSave": true
 }

--- a/src/object.h
+++ b/src/object.h
@@ -37,7 +37,7 @@ typedef struct {
 } ObjFunction;
 
 // Native functions need to be "their own thing" because they don't push a CallFrame when called.
-typedef Value (*NativeFn)(int argCount, Value* args);
+typedef bool (*NativeFn)(int argCount, Value* args);
 typedef struct {
     Obj obj;
     NativeFn function;

--- a/src/vm.c
+++ b/src/vm.c
@@ -30,6 +30,11 @@ static bool clockNative(int argCount, Value* args) {
 - If the native fails, return false and store error message in args[-1].
 (args[-1] previously held the function itself.) */
 static bool sqrtNative(int argCount, Value* args) {
+    if (argCount != 1) {
+        args[-1] = OBJ_VAL(copyString("Expected 1 argument.", 20));
+        return false;
+    }
+
     switch (args->type) {
         case VAL_NUMBER:
             args[-1] = NUMBER_VAL((double)sqrt(AS_NUMBER(*args)));

--- a/src/vm.c
+++ b/src/vm.c
@@ -8,6 +8,7 @@
 #include "common.h"
 #include "compiler.h"
 #include "debug.h"
+#include "math.h"
 #include "memory.h"
 #include "object.h"
 
@@ -19,13 +20,23 @@ static Value clockNative(int argCount, Value* args) {
     return NUMBER_VAL((double)clock() / CLOCKS_PER_SEC);
 }
 
+/* Native function to take square root. */
+static Value sqrtNative(int argCount, Value* args) {
+    if (IS_NUMBER(*args)) {
+        return NUMBER_VAL((double)sqrt(AS_NUMBER(*args)));
+    } else {
+        runtimeError("Expected number as input.");
+    }
+    return NIL_VAL;
+}
+
 static void resetStack() {
     vm.stackTop = vm.stack;
     vm.frameCount = 0;
 }
 
 /* Print a runtime error. Callers can pass a format string followed by arguments, just like 'printf()'. */
-static void runtimeError(const char* format, ...) {
+void runtimeError(const char* format, ...) {
     // Show error message
     va_list args;
     va_start(args, format);
@@ -66,6 +77,7 @@ void initVM() {
     initTable(&vm.globals);
     initTable(&vm.strings);
 
+    defineNative("sqrt", sqrtNative);
     defineNative("clock", clockNative);
 }
 

--- a/src/vm.c
+++ b/src/vm.c
@@ -22,10 +22,11 @@ static Value clockNative(int argCount, Value* args) {
 
 /* Native function to take square root. */
 static Value sqrtNative(int argCount, Value* args) {
-    if (IS_NUMBER(*args)) {
-        return NUMBER_VAL((double)sqrt(AS_NUMBER(*args)));
-    } else {
-        runtimeError("Expected number as input.");
+    switch (args->type) {
+        case VAL_BOOL:
+            return NUMBER_VAL((double)sqrt(AS_BOOL(*args)));
+        default:
+            return NIL_VAL;
     }
     return NIL_VAL;
 }

--- a/src/vm.h
+++ b/src/vm.h
@@ -34,6 +34,7 @@ typedef struct {
 
 extern VM vm;
 
+void runtimeError(const char* format, ...);
 void initVM();
 void freeVM();
 InterpretResult interpret(const char* source);


### PR DESCRIPTION
Adds a new native function, `sqrt()`.
Adds arity checking to native function calls. Throws a runtime error if arity is incorrect.
Adds a way for native functions to throw runtime errors.