### PR TITLE
Chapter 26 - Garbage Collection

### DIFF
--- a/src/chunk.c
+++ b/src/chunk.c
@@ -3,6 +3,7 @@
 #include <stdlib.h>
 
 #include "memory.h"
+#include "vm.h"
 
 /* Initialize empty dynamic array */
 void initChunk(Chunk* chunk) {
@@ -31,7 +32,9 @@ void writeChunk(Chunk* chunk, uint8_t byte, int line) {
 
 /*  Add a constant to the chunk, return its index */
 int addConstant(Chunk* chunk, Value value) {
+    push(value);  // Protect from GC
     writeValueArray(&chunk->constants, value);
+    pop();
     return chunk->constants.count - 1;
 }
 

--- a/src/common.h
+++ b/src/common.h
@@ -5,8 +5,11 @@
 #include <stddef.h>
 #include <stdint.h>
 
-// #define DEBUG_PRINT_CODE
-// #define DEBUG_TRACE_EXECUTION
+#define DEBUG_PRINT_CODE
+#define DEBUG_TRACE_EXECUTION
+
+#define DEBUG_STRESS_GC
+#define DEBUG_LOG_GC
 
 #define UINT8_COUNT (UINT8_MAX + 1)
 

--- a/src/common.h
+++ b/src/common.h
@@ -8,7 +8,7 @@
 #define DEBUG_PRINT_CODE
 #define DEBUG_TRACE_EXECUTION
 
-#define DEBUG_STRESS_GC
+// #define DEBUG_STRESS_GC
 #define DEBUG_LOG_GC
 
 #define UINT8_COUNT (UINT8_MAX + 1)

--- a/src/common.h
+++ b/src/common.h
@@ -5,11 +5,11 @@
 #include <stddef.h>
 #include <stdint.h>
 
-#define DEBUG_PRINT_CODE
-#define DEBUG_TRACE_EXECUTION
+// #define DEBUG_PRINT_CODE
+// #define DEBUG_TRACE_EXECUTION
 
 // #define DEBUG_STRESS_GC
-#define DEBUG_LOG_GC
+// #define DEBUG_LOG_GC
 
 #define UINT8_COUNT (UINT8_MAX + 1)
 

--- a/src/compiler.c
+++ b/src/compiler.c
@@ -5,6 +5,7 @@
 #include <string.h>
 
 #include "common.h"
+#include "memory.h"
 #include "scanner.h"
 
 #ifdef DEBUG_PRINT_CODE
@@ -925,4 +926,13 @@ ObjFunction* compile(const char* source) {
 
     ObjFunction* function = endCompiler();
     return parser.hadError ? NULL : function;
+}
+
+/* Mark reachable objects for GC. In practice these are just ObjFunctions we're compiling into. */
+void markCompilerRoots() {
+    Compiler* compiler = current;
+    while (compiler != NULL) {
+        markObject((Obj*)compiler->function);
+        compiler = compiler->enclosing;
+    }
 }

--- a/src/compiler.h
+++ b/src/compiler.h
@@ -5,5 +5,6 @@
 #include "vm.h"
 
 ObjFunction* compile(const char* source);
+void markCompilerRoots();
 
 #endif

--- a/src/memory.c
+++ b/src/memory.c
@@ -3,6 +3,7 @@
 #include <stdlib.h>
 
 #include "compiler.h"
+#include "object.h"
 #include "vm.h"
 
 #ifdef DEBUG_LOG_GC
@@ -127,7 +128,7 @@ static void blackenObject(Obj* object) {
 // Free an object
 static void freeObject(Obj* object) {
 #ifdef DEBUG_LOG_GC
-    printf("%p free type %d\n", (void*)object, object->type);
+    printf("%p free %s\n", (void*)object, objTypeAsString[object->type]);
 #endif
 
     switch (object->type) {

--- a/src/memory.c
+++ b/src/memory.c
@@ -2,6 +2,7 @@
 
 #include <stdlib.h>
 
+#include "compiler.h"
 #include "vm.h"
 
 #ifdef DEBUG_LOG_GC
@@ -10,18 +11,27 @@
 #include "debug.h"
 #endif
 
+#define GC_HEAP_GROW_FACTOR 2
+
 /**
  * Reallocate an array, creating/growing/shrinking/freeing space if needed
  *
  * Note: All we need to update a memory block is the first byte. The memory allocator maintains additional bookkeeping info for each block in the heap (incl size).
  */
 void* reallocate(void* pointer, size_t oldSize, size_t newSize) {
+    // Keep track of how many bytes we're allocating to help us decide when to run GC.
+    vm.bytesAllocated += newSize - oldSize;
+
     // GC itself calls reallocate, so don't trigger when freeing memory .
     if (newSize > oldSize) {
         // If defined, trigger GC at every moment for testing
 #ifdef DEBUG_STRESS_GC
         collectGarbage();
 #endif
+
+        if (vm.bytesAllocated > vm.nextGC) {
+            collectGarbage();
+        }
     }
 
     // If we empty the array, we deallocate
@@ -35,6 +45,83 @@ void* reallocate(void* pointer, size_t oldSize, size_t newSize) {
     void* result = realloc(pointer, newSize);
     if (result == NULL) exit(1);
     return result;
+}
+
+/* Mark object for GC */
+void markObject(Obj* object) {
+    if (object == NULL) return;
+    if (object->isMarked) return;  // Prevents looping on cycles
+
+#ifdef DEBUG_LOG_GC
+    printf("%p mark ", (void*)object);
+    printValue(OBJ_VAL(object));
+    printf("\n");
+#endif
+
+    object->isMarked = true;
+
+    // Mark objects as gray
+    if (vm.grayCapacity < vm.grayCount + 1) {
+        vm.grayCapacity = GROW_CAPACITY(vm.grayCapacity);
+        // Use system realloc instead of our own reallocate so we can't trigger a GC while doing a GC.
+        vm.grayStack = (Obj**)realloc(vm.grayStack,
+                                      sizeof(Obj*) * vm.grayCapacity);
+        // Allocation failed
+        if (vm.grayStack == NULL) exit(1);
+    }
+
+    vm.grayStack[vm.grayCount++] = object;
+}
+
+/* Mark value for GC */
+void markValue(Value value) {
+    // We only care about Values with heap allocation. (i.e. not numbers, bools, nil).
+    if (IS_OBJ(value)) markObject(AS_OBJ(value));
+}
+
+/* Mark all values in an (ObjFunction's) array of values. */
+static void markArray(ValueArray* array) {
+    for (int i = 0; i < array->count; i++) {
+        markValue(array->values[i]);
+    }
+}
+
+/**
+ * Recursively blacken objects.
+ *
+ * A object is black if its isMarked field is set but it is no longer in the gray stack
+ */
+static void blackenObject(Obj* object) {
+#ifdef DEBUG_LOG_GC
+    printf("%p blacken ", (void*)object);
+    printValue(OBJ_VAL(object));
+    printf("\n");
+#endif
+
+    switch (object->type) {
+        case OBJ_CLOSURE: {
+            ObjClosure* closure = (ObjClosure*)object;
+            markObject((Obj*)closure->function);
+            for (int i = 0; i < closure->upvalueCount; i++) {
+                markObject((Obj*)closure->upvalues[i]);
+            }
+            break;
+        }
+        case OBJ_FUNCTION: {
+            ObjFunction* function = (ObjFunction*)object;
+            markObject((Obj*)function->name);
+            markArray(&function->chunk.constants);
+            break;
+        }
+        case OBJ_UPVALUE:
+            markValue(((ObjUpvalue*)object)->closed);
+            break;
+        // These have no outgoing references
+        // TODO(optimization): don't mark these are gray in the first place. Just go straight to black.
+        case OBJ_NATIVE:
+        case OBJ_STRING:
+            break;
+    }
 }
 
 // Free an object
@@ -75,14 +162,87 @@ static void freeObject(Obj* object) {
     }
 }
 
+/* Mark all reachable roots */
+static void markRoots() {
+    // Most roots are locals/temporaries in the stack
+    for (Value* slot = vm.stack; slot < vm.stackTop; slot++) {
+        markValue(*slot);
+    }
+
+    // Closures in CallFrames
+    for (int i = 0; i < vm.frameCount; i++) {
+        markObject((Obj*)vm.frames[i].closure);
+    }
+
+    // Upvalues are also directly reachable
+    for (ObjUpvalue* upvalue = vm.openUpvalues;
+         upvalue != NULL;
+         upvalue = upvalue->next) {
+        markObject((Obj*)upvalue);
+    }
+
+    // Then, globals
+    markTable(&vm.globals);
+
+    // We deliberately don't mark vm.strings. The interned strings are handled differently, using weak references.
+
+    // GC can also run during compiling
+    markCompilerRoots();
+}
+
+/* Traverse stack of grays until all are black. */
+static void traceReferences() {
+    while (vm.grayCount > 0) {
+        Obj* object = vm.grayStack[--vm.grayCount];
+        blackenObject(object);
+    }
+}
+
+/* Delete all white objects. */
+static void sweep() {
+    Obj* previous = NULL;
+    Obj* object = vm.objects;
+
+    while (object != NULL) {
+        if (object->isMarked) {
+            object->isMarked = false;  // For next GC cycle
+            previous = object;
+            object = object->next;
+        } else {
+            // Removed unreached object from middle of linked list
+            Obj* unreached = object;
+            object = object->next;
+            if (previous != NULL) {
+                previous->next = object;
+            } else {
+                vm.objects = object;
+            }
+
+            freeObject(unreached);
+        }
+    }
+}
+
 /* Mark-and-sweep garbage collection. */
 void collectGarbage() {
 #ifdef DEBUG_LOG_GC
     printf("-- gc begin\n");
+    size_t before = vm.bytesAllocated;
 #endif
+
+    markRoots();
+    traceReferences();
+    tableRemoveWhite(&vm.strings);
+    sweep();
+
+    // After freeing objects, we determine that the next GC cycle will run once memory has grown by a certain factor
+    vm.nextGC = vm.bytesAllocated * GC_HEAP_GROW_FACTOR;
 
 #ifdef DEBUG_LOG_GC
     printf("-- gc end\n");
+    printf("   collected %zu bytes (from %zu to %zu) next at %zu\n",
+           before - vm.bytesAllocated, before, vm.bytesAllocated,
+           vm.nextGC);
 #endif
 }
 
@@ -94,4 +254,6 @@ void freeObjects() {
         freeObject(object);
         object = next;
     }
+
+    free(vm.grayStack);
 }

--- a/src/memory.h
+++ b/src/memory.h
@@ -23,6 +23,7 @@
     reallocate(pointer, sizeof(type) * (oldCount), 0)
 
 void* reallocate(void* pointer, size_t oldSize, size_t newSize);
+void collectGarbage();
 void freeObjects();
 
 #endif

--- a/src/memory.h
+++ b/src/memory.h
@@ -23,6 +23,8 @@
     reallocate(pointer, sizeof(type) * (oldCount), 0)
 
 void* reallocate(void* pointer, size_t oldSize, size_t newSize);
+void markObject(Obj* object);
+void markValue(Value value);
 void collectGarbage();
 void freeObjects();
 

--- a/src/object.c
+++ b/src/object.c
@@ -16,6 +16,7 @@
 static Obj* allocateObject(size_t size, ObjType type) {
     Obj* object = (Obj*)reallocate(NULL, 0, size);
     object->type = type;
+    object->isMarked = false;
 
     // every time we allocate an obj, update the global lsit of objects.
     // this is useful for GC
@@ -71,8 +72,14 @@ static ObjString* allocateString(char* chars, int length,
     string->length = length;
     string->chars = chars;
     string->hash = hash;
+
+    // Protect from GC. Here, the string is brand new, so it's not pointed to by anyone.
+    push(OBJ_VAL(string));
+
     // Intern every string we create
     tableSet(&vm.strings, string, NIL_VAL);
+    pop();
+
     return string;
 }
 

--- a/src/object.c
+++ b/src/object.c
@@ -21,6 +21,11 @@ static Obj* allocateObject(size_t size, ObjType type) {
     // this is useful for GC
     object->next = vm.objects;
     vm.objects = object;
+
+#ifdef DEBUG_LOG_GC
+    printf("%p allocate %zu for %d\n", (void*)object, size, type);
+#endif
+
     return object;
 }
 

--- a/src/object.h
+++ b/src/object.h
@@ -29,6 +29,7 @@ typedef enum {
 
 struct Obj {
     ObjType type;
+    bool isMarked;
     struct Obj* next;  // Intrusive pointer to next object for GC
 };
 

--- a/src/object.h
+++ b/src/object.h
@@ -27,6 +27,15 @@ typedef enum {
     OBJ_UPVALUE
 } ObjType;
 
+/* Maps the enum value to a string. */
+static const char* objTypeAsString[] = {
+    "closure",
+    "function",
+    "native",
+    "string",
+    "upvalue",
+};
+
 struct Obj {
     ObjType type;
     bool isMarked;

--- a/src/table.c
+++ b/src/table.c
@@ -151,3 +151,25 @@ ObjString* tableFindString(Table* table, const char* chars, int length, uint32_t
         index = (index + 1) % table->capacity;
     }
 }
+
+/**
+ * Delete all non-null entries that are marked white.
+ *
+ * This function is intended to be used to delete interned strings before the string Objs are swept by GC. This prevents dangling pointers to the table entries.  */
+void tableRemoveWhite(Table* table) {
+    for (int i = 0; i < table->capacity; i++) {
+        Entry* entry = &table->entries[i];
+        if (entry->key != NULL && !entry->key->obj.isMarked) {
+            tableDelete(table, entry->key);
+        }
+    }
+}
+
+/* Mark entries and key strings for GC*/
+void markTable(Table* table) {
+    for (int i = 0; i < table->capacity; i++) {
+        Entry* entry = &table->entries[i];
+        markObject((Obj*)entry->key);
+        markValue(entry->value);
+    }
+}

--- a/src/table.h
+++ b/src/table.h
@@ -22,5 +22,7 @@ bool tableSet(Table* table, ObjString* key, Value value);
 bool tableDelete(Table* table, ObjString* key);
 void tableAddAll(Table* from, Table* to);
 ObjString* tableFindString(Table* table, const char* chars, int length, uint32_t hash);
+void tableRemoveWhite(Table* table);
+void markTable(Table* table);
 
 #endif

--- a/src/vm.h
+++ b/src/vm.h
@@ -30,7 +30,13 @@ typedef struct {
     Table globals;             // Global vars
     Table strings;             // Stores ("interns") every string that's been created. Used for string deduplication.
     ObjUpvalue* openUpvalues;  // All open upvalues (i.e. not hoisted / still on the stack)
-    Obj* objects;              // Pointer to head of objects linked list
+
+    size_t bytesAllocated;
+    size_t nextGC;
+    Obj* objects;  // Pointer to head of objects linked list
+    int grayCount;
+    int grayCapacity;
+    Obj** grayStack;
 } VM;
 
 extern VM vm;


### PR DESCRIPTION
Adds a self-tuning mark-and-sweep garbage collector.

### Mark-and-sweep GC
The garbage collector works in three phases and uses a tricolour abstraction.

#### Tricolour abstraction
During garbage collection, objects can be one of three colours
- White: the object is not reached. At the beginning of GC, all objects are white.
- Gray: the object is reachable, but we haven't checked the objects it references yet.
- Black the object is reachable, and we've marked all the objects it references.

#### GC Phases
1. Mark the roots. We mark all the roots we know of:
   - Locals and temporaries on the stack
   - Closures in CallFrames
   - Upvalues
   - Globals
   - Compiler roots. These are the ObjFunctions we're compiling into.
2. Trace References. We start from the roots we marked in step 1 and mark all the objects they reference until we run out of gray objects.
3. Sweep. All remaining white objects are safely deleted.

There's an additional step between 2 and 3 (`tableRemoveWhite`), where we delete entries in the table of interned strings. This is to prevent the table from having dangling entries that point to strings that are going to be deleted in step 3.

### When to trigger GC
The first GC event occurs arbitrarily when we reach 1 MB of used space. Then, the next GC cycle will occur when we reach 2X the amount of memory left occupied after the previous GC event (self-tuning). 

This process could be improved using a generational collector such as [Java's G1GC](https://www.oracle.com/technetwork/tutorials/tutorials-1876574.html)