### PR TITLE
Chapter 27 - Classes and Instances

### DIFF
--- a/src/chunk.h
+++ b/src/chunk.h
@@ -18,6 +18,8 @@ typedef enum {
     OP_SET_GLOBAL,
     OP_GET_UPVALUE,
     OP_SET_UPVALUE,
+    OP_GET_PROPERTY,
+    OP_SET_PROPERTY,
     OP_EQUAL,
     OP_GREATER,
     OP_LESS,
@@ -35,6 +37,7 @@ typedef enum {
     OP_CLOSURE,
     OP_CLOSE_UPVALUE,
     OP_RETURN,  // One-byte opcode
+    OP_CLASS,
 } OpCode;
 
 // A "Chunk" of code.

--- a/src/compiler.c
+++ b/src/compiler.c
@@ -487,6 +487,22 @@ static void call(bool canAssign) {
     emitBytes(OP_CALL, argCount);
 }
 
+/**
+ * Dot operator to access instance properties
+ * (properties is an any named entity on an instance, fields are properties that have state associated with it.)
+ */
+static void dot(bool canAssign) {
+    consume(TOKEN_IDENTIFIER, "Expect property name after '.'.");
+    uint8_t name = identifierConstant(&parser.previous);
+
+    if (canAssign && match(TOKEN_EQUAL)) {
+        expression();
+        emitBytes(OP_SET_PROPERTY, name);
+    } else {
+        emitBytes(OP_GET_PROPERTY, name);
+    }
+}
+
 /* Push literals onto the stack */
 static void literal(bool canAssign) {
     switch (parser.previous.type) {
@@ -601,7 +617,7 @@ ParseRule rules[] = {
     [TOKEN_LEFT_BRACE] = {NULL, NULL, PREC_NONE},
     [TOKEN_RIGHT_BRACE] = {NULL, NULL, PREC_NONE},
     [TOKEN_COMMA] = {NULL, NULL, PREC_NONE},
-    [TOKEN_DOT] = {NULL, NULL, PREC_NONE},
+    [TOKEN_DOT] = {NULL, dot, PREC_CALL},
     [TOKEN_MINUS] = {unary, binary, PREC_TERM},
     [TOKEN_PLUS] = {NULL, binary, PREC_TERM},
     [TOKEN_SEMICOLON] = {NULL, NULL, PREC_NONE},
@@ -715,6 +731,20 @@ static void function(FunctionType type) {
         emitByte(compiler.upvalues[i].isLocal ? 1 : 0);
         emitByte(compiler.upvalues[i].index);
     }
+}
+
+static void classDeclaration() {
+    consume(TOKEN_IDENTIFIER, "Expect class name.");
+    // Add identifier to surrounding function's constant table.
+    uint8_t nameConstant = identifierConstant(&parser.previous);
+    // Bind name ot a variable
+    declareVariable();
+
+    emitBytes(OP_CLASS, nameConstant);
+    defineVariable(nameConstant);
+
+    consume(TOKEN_LEFT_BRACE, "Expect '{' before class body.");
+    consume(TOKEN_RIGHT_BRACE, "Expect '}' after class body.");
 }
 
 static void funDeclaration() {
@@ -877,7 +907,9 @@ static void synchronize() {
 
 /* Declarations is one of the two types of statements supported by Lox. They bind a new name to a value. */
 static void declaration() {
-    if (match(TOKEN_FUN)) {
+    if (match(TOKEN_CLASS)) {
+        classDeclaration();
+    } else if (match(TOKEN_FUN)) {
         funDeclaration();
     } else if (match(TOKEN_VAR)) {
         varDeclaration();

--- a/src/debug.c
+++ b/src/debug.c
@@ -83,6 +83,10 @@ int disassembleInstruction(Chunk* chunk, int offset) {
             return byteInstruction("OP_GET_UPVALUE", chunk, offset);
         case OP_SET_UPVALUE:
             return byteInstruction("OP_SET_UPVALUE", chunk, offset);
+        case OP_GET_PROPERTY:
+            return constantInstruction("OP_GET_PROPERTY", chunk, offset);
+        case OP_SET_PROPERTY:
+            return constantInstruction("OP_SET_PROPERTY", chunk, offset);
         case OP_EQUAL:
             return simpleInstruction("OP_EQUAL", offset);
         case OP_GREATER:
@@ -133,6 +137,8 @@ int disassembleInstruction(Chunk* chunk, int offset) {
             return simpleInstruction("OP_CLOSE_UPVALUE", offset);
         case OP_RETURN:
             return simpleInstruction("OP_RETURN", offset);
+        case OP_CLASS:
+            return constantInstruction("OP_CLASS", chunk, offset);
         default:
             printf("Unknown opcode %d\n", instruction);
             return offset + 1;

--- a/src/memory.c
+++ b/src/memory.c
@@ -100,6 +100,11 @@ static void blackenObject(Obj* object) {
 #endif
 
     switch (object->type) {
+        case OBJ_CLASS: {
+            ObjClass* loxClass = (ObjClass*)object;
+            markObject((Obj*)loxClass->name);  // Keep name alive too
+            break;
+        }
         case OBJ_CLOSURE: {
             ObjClosure* closure = (ObjClosure*)object;
             markObject((Obj*)closure->function);
@@ -112,6 +117,12 @@ static void blackenObject(Obj* object) {
             ObjFunction* function = (ObjFunction*)object;
             markObject((Obj*)function->name);
             markArray(&function->chunk.constants);
+            break;
+        }
+        case OBJ_INSTANCE: {
+            ObjInstance* instance = (ObjInstance*)object;
+            markObject((Obj*)instance->loxClass);
+            markTable(&instance->fields);
             break;
         }
         case OBJ_UPVALUE:
@@ -132,6 +143,10 @@ static void freeObject(Obj* object) {
 #endif
 
     switch (object->type) {
+        case OBJ_CLASS: {
+            FREE(ObjClass, object);
+            break;
+        }
         case OBJ_CLOSURE: {
             ObjClosure* closure = (ObjClosure*)object;
             FREE_ARRAY(ObjUpvalue*, closure->upvalues,
@@ -144,6 +159,13 @@ static void freeObject(Obj* object) {
             ObjFunction* function = (ObjFunction*)object;
             freeChunk(&function->chunk);
             FREE(ObjFunction, object);
+            break;
+        }
+        case OBJ_INSTANCE: {
+            ObjInstance* instance = (ObjInstance*)object;
+            // We just free the entry array of the table. The actual entries in the table are taken care of by the garbage collector.
+            freeTable(&instance->fields);
+            FREE(ObjInstance, object);
             break;
         }
         case OBJ_NATIVE:

--- a/src/object.c
+++ b/src/object.c
@@ -30,6 +30,13 @@ static Obj* allocateObject(size_t size, ObjType type) {
     return object;
 }
 
+/* Create new class object. */
+ObjClass* newClass(ObjString* name) {
+    ObjClass* loxClass = ALLOCATE_OBJ(ObjClass, OBJ_CLASS);
+    loxClass->name = name;
+    return loxClass;
+}
+
 /* Create new cluster that wraps a function. */
 ObjClosure* newClosure(ObjFunction* function) {
     // Allocate array of upvalues with correct size. The size was determined at compile time.
@@ -54,6 +61,14 @@ ObjFunction* newFunction() {
     initChunk(&function->chunk);
     function->name = NULL;
     return function;
+}
+
+/* Instantiate a class. */
+ObjInstance* newInstance(ObjClass* loxClass) {
+    ObjInstance* instance = ALLOCATE_OBJ(ObjInstance, OBJ_INSTANCE);
+    instance->loxClass = loxClass;
+    initTable(&instance->fields);
+    return instance;
 }
 
 /* Create new native function. Take a C function pointer and wrap it in an ObjNative. */
@@ -144,11 +159,18 @@ static void printFunction(ObjFunction* function) {
 
 void printObject(Value value) {
     switch (OBJ_TYPE(value)) {
+        case OBJ_CLASS:
+            printf("%s", AS_CLASS(value)->name->chars);
+            break;
         case OBJ_CLOSURE:
             printFunction(AS_CLOSURE(value)->function);
             break;
         case OBJ_FUNCTION:
             printFunction(AS_FUNCTION(value));
+            break;
+        case OBJ_INSTANCE:
+            printf("%s instance",
+                   AS_INSTANCE(value)->loxClass->name->chars);
             break;
         case OBJ_NATIVE:
             printf("<native fn>");

--- a/src/object.h
+++ b/src/object.h
@@ -3,25 +3,32 @@
 
 #include "chunk.h"
 #include "common.h"
+#include "table.h"
 #include "value.h"
 
 #define OBJ_TYPE(value) (AS_OBJ(value)->type)
 
+#define IS_CLASS(value) isObjType(value, OBJ_CLASS)
 #define IS_CLOSURE(value) isObjType(value, OBJ_CLOSURE)
 #define IS_FUNCTION(value) isObjType(value, OBJ_FUNCTION)
+#define IS_INSTANCE(value) isObjType(value, OBJ_INSTANCE)
 #define IS_NATIVE(value) isObjType(value, OBJ_NATIVE)
 #define IS_STRING(value) isObjType(value, OBJ_STRING)
 
+#define AS_CLASS(value) ((ObjClass*)AS_OBJ(value))
 #define AS_CLOSURE(value) ((ObjClosure*)AS_OBJ(value))
 #define AS_FUNCTION(value) ((ObjFunction*)AS_OBJ(value))
+#define AS_INSTANCE(value) ((ObjInstance*)AS_OBJ(value))
 #define AS_NATIVE(value) (((ObjNative*)AS_OBJ(value))->function)
 // These macros take a Value that is expected to have a pointer to a valid ObjString
 #define AS_STRING(value) ((ObjString*)AS_OBJ(value))
 #define AS_CSTRING(value) (((ObjString*)AS_OBJ(value))->chars)
 
 typedef enum {
+    OBJ_CLASS,
     OBJ_CLOSURE,
     OBJ_FUNCTION,
+    OBJ_INSTANCE,
     OBJ_NATIVE,
     OBJ_STRING,
     OBJ_UPVALUE
@@ -82,8 +89,21 @@ typedef struct {
     int upvalueCount;
 } ObjClosure;
 
+typedef struct {
+    Obj obj;
+    ObjString* name;
+} ObjClass;
+
+typedef struct {
+    Obj obj;
+    ObjClass* loxClass;
+    Table fields;
+} ObjInstance;
+
+ObjClass* newClass(ObjString* name);
 ObjClosure* newClosure(ObjFunction* function);
 ObjFunction* newFunction();
+ObjInstance* newInstance(ObjClass* loxClass);
 ObjNative* newNative(NativeFn function);
 ObjString* takeString(char* chars, int length);
 ObjString* copyString(const char* chars, int length);

--- a/test/chap27_classes.clox
+++ b/test/chap27_classes.clox
@@ -1,0 +1,10 @@
+class Brioche {}
+print Brioche;
+print Brioche();
+
+class Vector {}
+
+var v = Vector();
+v.x = 1;
+v.y = 2;
+print v.x + v.y;


### PR DESCRIPTION
Adds simple classes and instances. 

Methods and inheritance is outside the scope of this PR.

Classes can be created with the `class` token, e.g. `class Potato {}`.
- Classes can be declared inside a local scope. (Some languages forbid non-global class definitions.)

Instances can be constructed by calling a class, e.g. `var v = Vector();`. 
- Fields can be added to instances at runtime.
- Instance properties can be accessed via dot (`.`) notation.
- Each instance owns a table of fields