### PR TITLE
Chapter 28 - Add methods and initializers to Lox classes

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -21,7 +21,7 @@
       "id": "testFile",
       "type": "promptString",
       "description": "Test .clox file to debug",
-      "default": "test/chap23_control.clox"
+      "default": "test/chap28_simple_method.clox"
     }
   ]
 }

--- a/src/chunk.h
+++ b/src/chunk.h
@@ -34,10 +34,12 @@ typedef enum {
     OP_JUMP_IF_FALSE,
     OP_LOOP,
     OP_CALL,
+    OP_INVOKE,
     OP_CLOSURE,
     OP_CLOSE_UPVALUE,
     OP_RETURN,  // One-byte opcode
     OP_CLASS,
+    OP_METHOD,
 } OpCode;
 
 // A "Chunk" of code.

--- a/src/common.h
+++ b/src/common.h
@@ -5,8 +5,8 @@
 #include <stddef.h>
 #include <stdint.h>
 
-#define DEBUG_PRINT_CODE
-#define DEBUG_TRACE_EXECUTION
+// #define DEBUG_PRINT_CODE
+// #define DEBUG_TRACE_EXECUTION
 
 // #define DEBUG_STRESS_GC
 // #define DEBUG_LOG_GC

--- a/src/common.h
+++ b/src/common.h
@@ -5,8 +5,8 @@
 #include <stddef.h>
 #include <stdint.h>
 
-// #define DEBUG_PRINT_CODE
-// #define DEBUG_TRACE_EXECUTION
+#define DEBUG_PRINT_CODE
+#define DEBUG_TRACE_EXECUTION
 
 // #define DEBUG_STRESS_GC
 // #define DEBUG_LOG_GC

--- a/src/debug.c
+++ b/src/debug.c
@@ -45,6 +45,16 @@ static int constantInstruction(const char* name, Chunk* chunk, int offset) {
     return offset + 2;
 }
 
+static int invokeInstruction(const char* name, Chunk* chunk,
+                             int offset) {
+    uint8_t constant = chunk->code[offset + 1];
+    uint8_t argCount = chunk->code[offset + 2];
+    printf("%-16s (%d args) %4d '", name, argCount, constant);
+    printValue(chunk->constants.values[constant]);
+    printf("'\n");
+    return offset + 3;
+}
+
 /* Print instruction; Return the number of the offset of the next instruction. */
 int disassembleInstruction(Chunk* chunk, int offset) {
     printf("%04d ", offset);
@@ -115,6 +125,8 @@ int disassembleInstruction(Chunk* chunk, int offset) {
             return jumpInstruction("OP_LOOP", -1, chunk, offset);
         case OP_CALL:
             return byteInstruction("OP_CALL", chunk, offset);
+        case OP_INVOKE:
+            return invokeInstruction("OP_INVOKE", chunk, offset);
         case OP_CLOSURE: {
             offset++;
             uint8_t constant = chunk->code[offset++];
@@ -139,6 +151,8 @@ int disassembleInstruction(Chunk* chunk, int offset) {
             return simpleInstruction("OP_RETURN", offset);
         case OP_CLASS:
             return constantInstruction("OP_CLASS", chunk, offset);
+        case OP_METHOD:
+            return constantInstruction("OP_METHOD", chunk, offset);
         default:
             printf("Unknown opcode %d\n", instruction);
             return offset + 1;

--- a/src/object.c
+++ b/src/object.c
@@ -30,10 +30,21 @@ static Obj* allocateObject(size_t size, ObjType type) {
     return object;
 }
 
+/* Create new bound method from receiver (instance) and method. */
+ObjBoundMethod* newBoundMethod(Value receiver,
+                               ObjClosure* method) {
+    ObjBoundMethod* bound = ALLOCATE_OBJ(ObjBoundMethod,
+                                         OBJ_BOUND_METHOD);
+    bound->receiver = receiver;
+    bound->method = method;
+    return bound;
+}
+
 /* Create new class object. */
 ObjClass* newClass(ObjString* name) {
     ObjClass* loxClass = ALLOCATE_OBJ(ObjClass, OBJ_CLASS);
     loxClass->name = name;
+    initTable(&loxClass->methods);
     return loxClass;
 }
 
@@ -159,6 +170,9 @@ static void printFunction(ObjFunction* function) {
 
 void printObject(Value value) {
     switch (OBJ_TYPE(value)) {
+        case OBJ_BOUND_METHOD:
+            printFunction(AS_BOUND_METHOD(value)->method->function);
+            break;
         case OBJ_CLASS:
             printf("%s", AS_CLASS(value)->name->chars);
             break;

--- a/src/object.h
+++ b/src/object.h
@@ -8,6 +8,7 @@
 
 #define OBJ_TYPE(value) (AS_OBJ(value)->type)
 
+#define IS_BOUND_METHOD(value) isObjType(value, OBJ_BOUND_METHOD)
 #define IS_CLASS(value) isObjType(value, OBJ_CLASS)
 #define IS_CLOSURE(value) isObjType(value, OBJ_CLOSURE)
 #define IS_FUNCTION(value) isObjType(value, OBJ_FUNCTION)
@@ -15,6 +16,7 @@
 #define IS_NATIVE(value) isObjType(value, OBJ_NATIVE)
 #define IS_STRING(value) isObjType(value, OBJ_STRING)
 
+#define AS_BOUND_METHOD(value) ((ObjBoundMethod*)AS_OBJ(value))
 #define AS_CLASS(value) ((ObjClass*)AS_OBJ(value))
 #define AS_CLOSURE(value) ((ObjClosure*)AS_OBJ(value))
 #define AS_FUNCTION(value) ((ObjFunction*)AS_OBJ(value))
@@ -25,6 +27,7 @@
 #define AS_CSTRING(value) (((ObjString*)AS_OBJ(value))->chars)
 
 typedef enum {
+    OBJ_BOUND_METHOD,
     OBJ_CLASS,
     OBJ_CLOSURE,
     OBJ_FUNCTION,
@@ -92,6 +95,7 @@ typedef struct {
 typedef struct {
     Obj obj;
     ObjString* name;
+    Table methods;
 } ObjClass;
 
 typedef struct {
@@ -100,6 +104,18 @@ typedef struct {
     Table fields;
 } ObjInstance;
 
+/**
+ * A "bound method" is an object that represents a method that is bound to instance of a class.
+ * When a method is accessed, the interpreter creates a bound method object that combines the instance (receiver) and the closure (code that defines the method).
+ * The bound method can later be called as a function and, when invoked, the VM makes sure that 'this' refers to the correct instance the method was accessed from. */
+typedef struct {
+    Obj obj;
+    Value receiver;  // Instance (as Value so we avoid conversions)
+    ObjClosure* method;
+} ObjBoundMethod;
+
+ObjBoundMethod* newBoundMethod(Value receiver,
+                               ObjClosure* method);
 ObjClass* newClass(ObjString* name);
 ObjClosure* newClosure(ObjFunction* function);
 ObjFunction* newFunction();

--- a/src/vm.c
+++ b/src/vm.c
@@ -87,6 +87,10 @@ void initVM() {
     initTable(&vm.globals);
     initTable(&vm.strings);
 
+    // Intern the string 'init' so we can access it quickly
+    vm.initString = copyString("init", 4);
+    vm.initString = NULL;
+
     defineNative("clock", clockNative);
     defineNative("hasAttr", hasAttrNative);
 }
@@ -95,6 +99,7 @@ void initVM() {
 void freeVM() {
     freeTable(&vm.globals);
     freeTable(&vm.strings);
+    vm.initString = NULL;
     freeObjects();
 }
 
@@ -139,11 +144,28 @@ static bool call(ObjClosure* closure, int argCount) {
 static bool callValue(Value callee, int argCount) {
     if (IS_OBJ(callee)) {
         switch (OBJ_TYPE(callee)) {
+            case OBJ_BOUND_METHOD: {
+                ObjBoundMethod* bound = AS_BOUND_METHOD(callee);
+                // When a method is called, put the instance in slot zero of the callframe
+                vm.stackTop[-argCount - 1] = bound->receiver;
+                return call(bound->method, argCount);
+            }
             case OBJ_CLASS: {
                 // If the Value being callend (the object resulting from calling the expr to the left of the opening parenthesis) is a class, treat it as constructor call
                 ObjClass* loxClass = AS_CLASS(callee);
                 // Store the result on the stack right before the arguments
                 vm.stackTop[-argCount - 1] = OBJ_VAL(newInstance(loxClass));
+
+                Value initializer;
+                if (tableGet(&loxClass->methods, vm.initString,
+                             &initializer)) {
+                    return call(AS_CLOSURE(initializer), argCount);
+                } else if (argCount != 0) {
+                    runtimeError("Expected 0 arguments but got %d.",
+                                 argCount);
+                    return false;
+                }
+
                 return true;
             }
             case OBJ_CLOSURE:
@@ -162,6 +184,53 @@ static bool callValue(Value callee, int argCount) {
     }
     runtimeError("Can only call functions and classes.");
     return false;
+}
+
+/* Combines OP_GET_PROPERTY and OP_CALL to speed up how fast we can invoke methods. */
+static bool invokeFromClass(ObjClass* loxClass, ObjString* name,
+                            int argCount) {
+    Value method;
+    if (!tableGet(&loxClass->methods, name, &method)) {
+        runtimeError("Undefined property '%s'.", name->chars);
+        return false;
+    }
+    return call(AS_CLOSURE(method), argCount);
+}
+
+/* Invoke a method */
+static bool invoke(ObjString* name, int argCount) {
+    Value receiver = peek(argCount);  // the receiving instance is slot zero
+
+    if (!IS_INSTANCE(receiver)) {
+        runtimeError("Only instances have methods.");
+        return false;
+    }
+
+    ObjInstance* instance = AS_INSTANCE(receiver);
+
+    // Check if we're actually calling a field (that references a function) instead of a method
+    Value value;
+    if (tableGet(&instance->fields, name, &value)) {
+        vm.stackTop[-argCount - 1] = value;
+        return callValue(value, argCount);
+    }
+
+    return invokeFromClass(instance->loxClass, name, argCount);
+}
+
+/* Bind a method to an instance */
+static bool bindMethod(ObjClass* loxClass, ObjString* name) {
+    Value method;
+    if (!tableGet(&loxClass->methods, name, &method)) {
+        runtimeError("Undefined property '%s'.", name->chars);
+        return false;
+    }
+
+    ObjBoundMethod* bound = newBoundMethod(peek(0),
+                                           AS_CLOSURE(method));
+    pop();
+    push(OBJ_VAL(bound));
+    return true;
 }
 
 /**
@@ -209,6 +278,13 @@ static void closeUpvalues(Value* last) {
         upvalue->location = &upvalue->closed;  // Point the location to the Upvalue's own closed field. That way, whenever the program wants to dereference the location to get the variable value, it will access the Upvalue itself. This essentially "closes" the upvalue so the hereon variable's value is stored in the heap instead of the stack.
         vm.openUpvalues = upvalue->next;
     }
+}
+
+static void defineMethod(ObjString* name) {
+    Value method = peek(0);  // Method closure
+    ObjClass* loxClass = AS_CLASS(peek(1));
+    tableSet(&loxClass->methods, name, method);
+    pop();
 }
 
 /* nil and false are falsey. Everything else is truthy*/
@@ -373,9 +449,10 @@ static InterpretResult run() {
                     push(value);
                     break;
                 }
-
-                runtimeError("Undefined property '%s'.", name->chars);
-                return INTERPRET_RUNTIME_ERROR;
+                if (!bindMethod(instance->loxClass, name)) {
+                    return INTERPRET_RUNTIME_ERROR;
+                }
+                break;
             }
             case OP_SET_PROPERTY: {
                 if (!IS_INSTANCE(peek(1))) {
@@ -460,6 +537,15 @@ static InterpretResult run() {
                 frame = &vm.frames[vm.frameCount - 1];
                 break;
             }
+            case OP_INVOKE: {
+                ObjString* method = READ_STRING();  // method name is first operand
+                int argCount = READ_BYTE();         // argcount is second operand
+                if (!invoke(method, argCount)) {
+                    return INTERPRET_RUNTIME_ERROR;
+                }
+                frame = &vm.frames[vm.frameCount - 1];
+                break;
+            }
             case OP_CLOSURE: {
                 // Load compuled function from constant table
                 ObjFunction* function = AS_FUNCTION(READ_CONSTANT());
@@ -504,6 +590,9 @@ static InterpretResult run() {
             }
             case OP_CLASS:
                 push(OBJ_VAL(newClass(READ_STRING())));
+                break;
+            case OP_METHOD:
+                defineMethod(READ_STRING());
                 break;
         }
     }

--- a/src/vm.c
+++ b/src/vm.c
@@ -88,8 +88,8 @@ void initVM() {
     initTable(&vm.strings);
 
     // Intern the string 'init' so we can access it quickly
-    vm.initString = copyString("init", 4);
     vm.initString = NULL;
+    vm.initString = copyString("init", 4);
 
     defineNative("clock", clockNative);
     defineNative("hasAttr", hasAttrNative);
@@ -157,7 +157,8 @@ static bool callValue(Value callee, int argCount) {
                 vm.stackTop[-argCount - 1] = OBJ_VAL(newInstance(loxClass));
 
                 Value initializer;
-                if (tableGet(&loxClass->methods, vm.initString,
+                if (tableGet(&loxClass->methods,
+                             vm.initString,
                              &initializer)) {
                     return call(AS_CLOSURE(initializer), argCount);
                 } else if (argCount != 0) {

--- a/src/vm.h
+++ b/src/vm.h
@@ -29,6 +29,7 @@ typedef struct {
     Value* stackTop;           // Use actual pointer instead of int index (faster dereferencing)
     Table globals;             // Global vars
     Table strings;             // Stores ("interns") every string that's been created. Used for string deduplication.
+    ObjString* initString;     // For fast access to the string 'init'
     ObjUpvalue* openUpvalues;  // All open upvalues (i.e. not hoisted / still on the stack)
 
     size_t bytesAllocated;

--- a/test/chap28_class_with_initializer.clox
+++ b/test/chap28_class_with_initializer.clox
@@ -1,0 +1,15 @@
+class CoffeeMaker {
+  init(coffee) {
+    this.coffee = coffee;
+  }
+
+  brew() {
+    print "Enjoy your cup of " + this.coffee;
+
+    // No reusing the grounds!
+    this.coffee = nil;
+  }
+}
+
+var maker = CoffeeMaker("coffee and chicory");
+maker.brew();

--- a/test/chap28_class_with_initializer.clox
+++ b/test/chap28_class_with_initializer.clox
@@ -1,15 +1,23 @@
-class CoffeeMaker {
-  init(coffee) {
-    this.coffee = coffee;
+class Car {
+  init(model) {
+    this.model = model;
   }
 
-  brew() {
-    print "Enjoy your cup of " + this.coffee;
+  readModel() {
+    if (this.model){
+      print "This car is a " + this.model + " 👍";
+    } else {
+      print "Can't tell what the model is 🤷🏼";
+    }
+  }
 
-    // No reusing the grounds!
-    this.coffee = nil;
+  crash() {
+    print "The car crashed 😭";
+    this.model = nil;
   }
 }
 
-var maker = CoffeeMaker("coffee and chicory");
-maker.brew();
+var car = Car("Porsche 911");
+car.readModel();
+car.crash();
+car.readModel();

--- a/test/chap28_function_field.clox
+++ b/test/chap28_function_field.clox
@@ -1,0 +1,22 @@
+class Car {
+  init(model) {
+    this.milesTravelled = 0;
+
+    fun driveMiles(miles){
+        this.milesTravelled = this.milesTravelled + miles;
+    }
+
+    this.drive = driveMiles;
+  }
+
+  readMilesTravelled(){
+    print(this.milesTravelled);
+  }
+}
+
+var car = Car("Porsche 911");
+car.readMilesTravelled();
+car.drive(1);
+car.readMilesTravelled();
+car.drive(5);
+car.readMilesTravelled();

--- a/test/chap28_simple_method.clox
+++ b/test/chap28_simple_method.clox
@@ -1,0 +1,8 @@
+class Lawn {
+  mow(personName) {
+    print personName + " is mowing the lawn.";
+  }
+}
+
+var lawn = Lawn();
+lawn.mow("Jimmy");


### PR DESCRIPTION
Adds methods and initializers to Lox classes.

**Methods** add behaviour to classes/instances.
- When the user access a method, the method is bound to the instance it is being accessed from. 
  - This is called a "bound method" (similar to CPython). Under the hood, we create a `ObjBoundMethod` object that combine the instance and method. `ObjBoundMethod` ensures that `this` refers to the correct instance.
- The instance can be referenced with the keyword `init`.
- Note: Lox does not have field declarations. All declarations in a class are methods.

**Initializers** are created using the special  `init(...)` method.
- Initializers are optional.
- Users cannot return values from initializers. The returned value would never be seen, as the initializer will always return the new instance.

This PR also adds an **optimization**: `OP_INVOKE`. This operation is emitted when we call a method right after accessing the instance, e.g. `myInstance.myMethod()`. `OP_INVOKE` essentially combines method access and call (`OP_GET_PROPERTY` and `OP_CALL`) into a single operation to speed up how fast the VM can invoke methods. 
- These two operations are generally executed together, so this is a significant optimization. 
- At runtime, the VM executes `OP_INVOKE` by looking up the method name, reading the argument count, and invoking the method on the receiver object. 
- This optimization eliminates the overhead of allocating and initializing `ObjBoundMethod` objects.




