### PR TITLE
Chapter 29 - Superclasses

### DIFF
--- a/src/chunk.h
+++ b/src/chunk.h
@@ -21,6 +21,7 @@ typedef enum {
     OP_GET_PROPERTY,
     OP_SET_PROPERTY,
     OP_EQUAL,
+    OP_GET_SUPER,
     OP_GREATER,
     OP_LESS,
     OP_ADD,
@@ -35,6 +36,7 @@ typedef enum {
     OP_LOOP,
     OP_CALL,
     OP_INVOKE,
+    OP_SUPER_INVOKE,
     OP_CLOSURE,
     OP_CLOSE_UPVALUE,
     OP_RETURN,  // One-byte opcode

--- a/src/chunk.h
+++ b/src/chunk.h
@@ -39,6 +39,7 @@ typedef enum {
     OP_CLOSE_UPVALUE,
     OP_RETURN,  // One-byte opcode
     OP_CLASS,
+    OP_INHERIT,
     OP_METHOD,
 } OpCode;
 

--- a/src/debug.c
+++ b/src/debug.c
@@ -151,6 +151,8 @@ int disassembleInstruction(Chunk* chunk, int offset) {
             return simpleInstruction("OP_RETURN", offset);
         case OP_CLASS:
             return constantInstruction("OP_CLASS", chunk, offset);
+        case OP_INHERIT:
+            return simpleInstruction("OP_INHERIT", offset);
         case OP_METHOD:
             return constantInstruction("OP_METHOD", chunk, offset);
         default:

--- a/src/debug.c
+++ b/src/debug.c
@@ -97,6 +97,8 @@ int disassembleInstruction(Chunk* chunk, int offset) {
             return constantInstruction("OP_GET_PROPERTY", chunk, offset);
         case OP_SET_PROPERTY:
             return constantInstruction("OP_SET_PROPERTY", chunk, offset);
+        case OP_GET_SUPER:
+            return constantInstruction("OP_GET_SUPER", chunk, offset);
         case OP_EQUAL:
             return simpleInstruction("OP_EQUAL", offset);
         case OP_GREATER:
@@ -127,6 +129,8 @@ int disassembleInstruction(Chunk* chunk, int offset) {
             return byteInstruction("OP_CALL", chunk, offset);
         case OP_INVOKE:
             return invokeInstruction("OP_INVOKE", chunk, offset);
+        case OP_SUPER_INVOKE:
+            return invokeInstruction("OP_SUPER_INVOKE", chunk, offset);
         case OP_CLOSURE: {
             offset++;
             uint8_t constant = chunk->code[offset++];

--- a/src/vm.c
+++ b/src/vm.c
@@ -592,6 +592,22 @@ static InterpretResult run() {
             case OP_CLASS:
                 push(OBJ_VAL(newClass(READ_STRING())));
                 break;
+            case OP_INHERIT: {
+                Value superclass = peek(1);
+
+                if (!IS_CLASS(superclass)) {
+                    runtimeError("Superclass must be a class.");
+                    return INTERPRET_RUNTIME_ERROR;
+                }
+
+                ObjClass* subclass = AS_CLASS(peek(0));
+                // "Copy down inheritance"
+                // This works because class methods can't be modified at runtime.
+                tableAddAll(&AS_CLASS(superclass)->methods,
+                            &subclass->methods);
+                pop();
+                break;
+            }
             case OP_METHOD:
                 defineMethod(READ_STRING());
                 break;

--- a/test/chap29_superclasses.lox
+++ b/test/chap29_superclasses.lox
@@ -1,0 +1,25 @@
+class Vehicle    {
+    init(type){
+        this.type = type;
+    }
+
+    printType(){
+        print this.type;
+    }
+}
+
+class Car < Vehicle {
+  init(model) {
+    super.init("Automobile");
+    
+    fun printInfo(){
+        super.printType();
+        print model;
+    }
+
+    this.printInfo = printInfo;
+  }
+}
+
+var car = Car("Porsche 911");
+car.printInfo();


### PR DESCRIPTION
Adds inheritance and superclasses.
- Superclass methods can be accessed via `super.<method name>()`.
- Multiple inheritance and accessing a superclass's fields isn't supported.

Implementation details:
- Inheritance in Lox works by _copying down_ the superclasses methods to the subclass's `methods` table via the `OP_INHERIT` instruction. This only works because class methods can't be modified at runtime.
- Inheritance is done before declaring the subclass's methods so the superclass's methods are overwritten.
- To be able to reference a superclass in a subclass, we create a scope and transparently define a variable called `super` in it. (`super` is a protected keyword.) Then, the subclass methods can automatically access this variable via an Upvalue.
- `OP_GET_SUPER` looks up the method in the superclass' table and create an `ObjBoundMethod`.


We also add an optimization similar to [the one for Chapher 28](https://github.com/CaioCamatta/clox/pull/18#issue-1806306348): `OP_SUPER_INVOKE`. This operation combines the functionality of `OP_GET_SUPER` and `OP_CALL`.