### PR TITLE
Chapter 30 - Optimizations

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ OBJECTS := $(patsubst $(SRC)/%.c, $(OBJ)/%.o, $(wildcard $(SRC)/*.c))
 
 all: $(EXE)
 
-debug: CFLAGS += -g
+debug: CFLAGS += -pg
 debug: $(EXE)
 
 $(EXE): $(SRC) $(OBJ) $(OBJECTS)

--- a/src/common.h
+++ b/src/common.h
@@ -5,6 +5,8 @@
 #include <stddef.h>
 #include <stdint.h>
 
+#define NAN_BOXING  // Use NaN boxing for Values
+
 // #define DEBUG_PRINT_CODE
 // #define DEBUG_TRACE_EXECUTION
 

--- a/src/table.c
+++ b/src/table.c
@@ -22,7 +22,7 @@ void freeTable(Table* table) {
 
 /* Take a key and an array of "buckets" (entries) and find which bucket the key belongs to. Returns a pointer to the bucket. */
 static Entry* findEntry(Entry* entries, int capacity, ObjString* key) {
-    uint32_t index = key->hash % capacity;
+    uint32_t index = key->hash & (capacity - 1);
 
     Entry* tombstone = NULL;
 
@@ -47,7 +47,7 @@ static Entry* findEntry(Entry* entries, int capacity, ObjString* key) {
             return entry;
         }
 
-        index = (index + 1) % capacity;
+        index = (index + 1) & (capacity - 1);
     }
 }
 
@@ -135,7 +135,7 @@ void tableAddAll(Table* from, Table* to) {
 ObjString* tableFindString(Table* table, const char* chars, int length, uint32_t hash) {
     if (table->count == 0) return NULL;
 
-    uint32_t index = hash % table->capacity;
+    uint32_t index = hash & (table->capacity - 1);
     for (;;) {
         Entry* entry = &table->entries[index];
         if (entry->key == NULL) {
@@ -148,7 +148,7 @@ ObjString* tableFindString(Table* table, const char* chars, int length, uint32_t
             return entry->key;
         }
 
-        index = (index + 1) % table->capacity;
+        index = (index + 1) & (table->capacity - 1);
     }
 }
 

--- a/src/value.c
+++ b/src/value.c
@@ -30,6 +30,17 @@ void freeValueArray(ValueArray* array) {
 }
 
 void printValue(Value value) {
+#ifdef NAN_BOXING
+    if (IS_BOOL(value)) {
+        printf(AS_BOOL(value) ? "true" : "false");
+    } else if (IS_NIL(value)) {
+        printf("nil");
+    } else if (IS_NUMBER(value)) {
+        printf("%g", AS_NUMBER(value));
+    } else if (IS_OBJ(value)) {
+        printObject(value);
+    }
+#else
     switch (value.type) {
         case VAL_BOOL:
             printf(AS_BOOL(value) ? "true" : "false");
@@ -44,9 +55,17 @@ void printValue(Value value) {
             printObject(value);
             break;
     }
+#endif
 }
 
 bool valuesEqual(Value a, Value b) {
+#ifdef NAN_BOXING
+    // The if statement is so nan != nan and we're compliant w IEEE-754
+    if (IS_NUMBER(a) && IS_NUMBER(b)) {
+        return AS_NUMBER(a) == AS_NUMBER(b);
+    }
+    return a == b;
+#else
     if (a.type != b.type) return false;
     switch (a.type) {
         case VAL_BOOL:
@@ -60,4 +79,5 @@ bool valuesEqual(Value a, Value b) {
         default:
             return false;  // Unreachable.
     }
+#endif
 }

--- a/test/chap30_benchmark_zoo.lox
+++ b/test/chap30_benchmark_zoo.lox
@@ -1,0 +1,31 @@
+class Zoo {
+  init() {
+    this.aardvark = 1;
+    this.baboon   = 1;
+    this.cat      = 1;
+    this.donkey   = 1;
+    this.elephant = 1;
+    this.fox      = 1;
+  }
+  ant()    { return this.aardvark; }
+  banana() { return this.baboon; }
+  tuna()   { return this.cat; }
+  hay()    { return this.donkey; }
+  grass()  { return this.elephant; }
+  mouse()  { return this.fox; }
+}
+
+var zoo = Zoo();
+var sum = 0;
+var start = clock();
+while (sum < 100000000) {
+  sum = sum + zoo.ant()
+            + zoo.banana()
+            + zoo.tuna()
+            + zoo.hay()
+            + zoo.grass()
+            + zoo.mouse();
+}
+
+print clock() - start;
+print sum;


### PR DESCRIPTION
Adds two optimizations and a benchmark.

#### Hash table probing
First, we optimize hash table probing, by replacing the modulo operator in `findEntry` (and in `tableFindString`, secondarily) with a bitwise AND. This is possible because we know the capacity always grows by a factor of two, which allows us to use bit masking [[explanation](https://mziccard.me/2015/05/08/modulo-and-division-vs-bitwise-operations/)].

On my M1 Pro Macbook, this change decreases the execution time of the Zoo Benchmark by **12%**.

#### NaN boxing
Then, we use NaN boxing to reduce the size of a `Value` to 8 bytes. The existing design uses a 4-byte tag + an 8-byte union + some padding (4 bytes on a 64-bit computer), for a total of 16 bytes. To reduce that size, we take advantage of some of the special bits in the IEEE-754 standard. 

Number values use the same representation as IEEE-754. However, if the value is a NaN ([i.e., has all the exponent bits set](https://en.wikipedia.org/wiki/NaN#Floating_point)), we use the remaining bits for other object types.

Let the most significant bit be bit 63, and the [quiet NaN](https://en.wikipedia.org/wiki/NaN#Quiet_NaN) (`QNAN`) bits be bits 62 to 50 inclusive.
- Object values have `QNAN` set and the sign bit (63) set. The remaining 50 bits encode an 8-byte pointer. This is only possible from the assumption (observation?) that computer architectures generally only use the lowest 48 bits to encode pointers because that's enough to address ~200 TB of memory.
- Nil and boolean have `QNAN` set. We use the lowest 2 bites for nil, true, false.

On top of decreasing memory usage, this optimization also has positive implications on speed because shorter values =  fewer cache misses. On my computer, this decreases the execution time of the Zoo Benchmark by **11%**.